### PR TITLE
Fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -626,7 +626,7 @@ exports.decorateTerm = (Term, {React}) => {
         }
       }
       if (this.props.onDecorated) {
-        this.onDecorated(term);
+        this.props.onDecorated(term);
       }
     }
 


### PR DESCRIPTION
Inside of `exports.decorateTerm`, the `onDecorated` method calls itself instead of calling `this.props.onDecorated`.