### PR TITLE
Remove duplicated keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "hyperterm",
     "pane",
     "navigation",
-    "hyper-plugin",
     "plugin"
   ],
   "plugin": {


### PR DESCRIPTION
I think the keyword `hyper-plugin` is duplicated.