### PR TITLE
Fix compabitility with other plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -670,12 +670,13 @@ exports.decorateTerm = (Term, {React}) => {
       const myCustomChildrenBefore = React.createElement(
         'div',
         {
+          key: 'pane',
           style: config.indicatorStyle
         },
         indicator
       );
       const customChildrenBefore = this.props.customChildrenBefore
-        ? Array.from(this.props.customChildrenBefore).concat(myCustomChildrenBefore)
+        ? Array(this.props.customChildrenBefore).concat(myCustomChildrenBefore)
         : myCustomChildrenBefore;
       props.customChildrenBefore = customChildrenBefore;
       return React.createElement(Term, Object.assign({}, this.props, props));


### PR DESCRIPTION
```js
> s = {'a':1}
{ a: 1 }
> Array.from(s)
[]
> Array(s)
[ { a: 1 } ]
>
```